### PR TITLE
sort resource stage promt

### DIFF
--- a/internal/provider/resource_stage_prompt.go
+++ b/internal/provider/resource_stage_prompt.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -72,6 +73,9 @@ func resourceStagePromptRead(ctx context.Context, d *schema.ResourceData, m inte
 	if err != nil {
 		return httpToDiag(d, hr, err)
 	}
+
+	sort.Strings(res.Fields)
+	sort.Strings(res.ValidationPolicies)
 
 	d.Set("name", res.Name)
 	d.Set("fields", res.Fields)

--- a/internal/provider/resource_stage_prompt.go
+++ b/internal/provider/resource_stage_prompt.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -74,12 +73,11 @@ func resourceStagePromptRead(ctx context.Context, d *schema.ResourceData, m inte
 		return httpToDiag(d, hr, err)
 	}
 
-	sort.Strings(res.Fields)
-	sort.Strings(res.ValidationPolicies)
-
 	d.Set("name", res.Name)
-	d.Set("fields", res.Fields)
-	d.Set("validation_policies", res.ValidationPolicies)
+	fields := sliceToString(d.Get("fields").([]interface{}))
+	d.Set("fields", stringListConsistentMerge(fields, res.Fields))
+	validationPolicies := sliceToString(d.Get("validation_policies").([]interface{}))
+	d.Set("validation_policies", stringListConsistentMerge(validationPolicies, res.ValidationPolicies))
 	return diags
 }
 


### PR DESCRIPTION
The resource_stage_promt resource was being returned in inverse order and therefore generating always the following diff by terraform apply:

```
  ~ resource "authentik_stage_prompt" "password_change" {
      ~ fields              = [
          - "2bc5513c-0e3f-4e60-937d-6c001a589eb4",
            "0610c421-d7fa-45ff-a6c8-14e4329f5fca",
          + "2bc5513c-0e3f-4e60-937d-6c001a589eb4",
        ]
        id                  = "2a4533c2-5e1f-4cce-a761-76a2b876ce6a"
        name                = "terraform_password_change"
        # (1 unchanged attribute hidden)
    }
```

This PR sorts the reply from the API to avoid the delta.