### PR TITLE
use yaml instead of json

### DIFF
--- a/internal/provider/resource_blueprint_instance.go
+++ b/internal/provider/resource_blueprint_instance.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "goauthentik.io/api/v3"
+	"gopkg.in/yaml.v3"
 )
 
 func resourceBlueprintInstance() *schema.Resource {
@@ -53,7 +53,7 @@ func resourceBlueprintInstanceSchemaToModel(d *schema.ResourceData, c *APIClient
 
 	ctx := make(map[string]interface{})
 	if l, ok := d.Get("context").(string); ok && l != "" {
-		err := json.NewDecoder(strings.NewReader(l)).Decode(&ctx)
+		err := yaml.NewDecoder(strings.NewReader(l)).Decode(&ctx)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -92,7 +92,7 @@ func resourceBlueprintInstanceRead(ctx context.Context, d *schema.ResourceData, 
 	setWrapper(d, "name", res.Name)
 	setWrapper(d, "path", res.Path)
 	setWrapper(d, "enabled", res.Enabled)
-	b, err := json.Marshal(res.Context)
+	b, err := yaml.Marshal(res.Context)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "goauthentik.io/api/v3"
+	"gopkg.in/yaml.v3"
 )
 
 func resourceGroup() *schema.Resource {
@@ -70,7 +70,7 @@ func resourceGroupSchemaToModel(d *schema.ResourceData, c *APIClient) (*api.Grou
 
 	attr := make(map[string]interface{})
 	if l, ok := d.Get("attributes").(string); ok && l != "" {
-		err := json.NewDecoder(strings.NewReader(l)).Decode(&attr)
+		err := yaml.NewDecoder(strings.NewReader(l)).Decode(&attr)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -107,7 +107,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, m interface{
 
 	setWrapper(d, "name", res.Name)
 	setWrapper(d, "is_superuser", res.IsSuperuser)
-	b, err := json.Marshal(res.Attributes)
+	b, err := yaml.Marshal(res.Attributes)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_outpost.go
+++ b/internal/provider/resource_outpost.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "goauthentik.io/api/v3"
+	"gopkg.in/yaml.v3"
 )
 
 func resourceOutpost() *schema.Resource {
@@ -74,7 +74,7 @@ func resourceOutpostSchemaToModel(d *schema.ResourceData, c *APIClient) (*api.Ou
 	}
 	if l, ok := d.Get("config").(string); ok && l != "" {
 		var c map[string]interface{}
-		err := json.NewDecoder(strings.NewReader(l)).Decode(&c)
+		err := yaml.NewDecoder(strings.NewReader(l)).Decode(&c)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -120,7 +120,7 @@ func resourceOutpostRead(ctx context.Context, d *schema.ResourceData, m interfac
 	if res.ServiceConnection.IsSet() {
 		setWrapper(d, "service_connection", res.ServiceConnection.Get())
 	}
-	b, err := json.Marshal(res.Config)
+	b, err := yaml.Marshal(res.Config)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_outpost_sc_kubernetes.go
+++ b/internal/provider/resource_outpost_sc_kubernetes.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "goauthentik.io/api/v3"
+	"gopkg.in/yaml.v3"
 )
 
 func resourceServiceConnectionKubernetes() *schema.Resource {
@@ -51,7 +51,7 @@ func resourceServiceConnectionKubernetesSchemaToModel(d *schema.ResourceData) (*
 
 	if l, ok := d.Get("kubeconfig").(string); ok {
 		var c map[string]interface{}
-		err := json.NewDecoder(strings.NewReader(l)).Decode(&c)
+		err := yaml.NewDecoder(strings.NewReader(l)).Decode(&c)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -89,7 +89,7 @@ func resourceServiceConnectionKubernetesRead(ctx context.Context, d *schema.Reso
 
 	setWrapper(d, "name", res.Name)
 	setWrapper(d, "local", res.Local)
-	b, err := json.Marshal(res.Kubeconfig)
+	b, err := yaml.Marshal(res.Kubeconfig)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_source_oauth.go
+++ b/internal/provider/resource_source_oauth.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "goauthentik.io/api/v3"
+	"gopkg.in/yaml.v3"
 )
 
 func resourceSourceOAuth() *schema.Resource {
@@ -172,7 +172,7 @@ func resourceSourceOAuthSchemaToSource(d *schema.ResourceData) (*api.OAuthSource
 	}
 	if l, ok := d.Get("oidc_jwks").(string); ok && l != "" {
 		var c map[string]interface{}
-		err := json.NewDecoder(strings.NewReader(l)).Decode(&c)
+		err := yaml.NewDecoder(strings.NewReader(l)).Decode(&c)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -238,7 +238,7 @@ func resourceSourceOAuthRead(ctx context.Context, d *schema.ResourceData, m inte
 	setWrapper(d, "callback_uri", res.CallbackUrl)
 	setWrapper(d, "oidc_well_known_url", res.GetOidcWellKnownUrl())
 	setWrapper(d, "oidc_jwks_url", res.GetOidcJwksUrl())
-	b, err := json.Marshal(res.GetOidcJwks())
+	b, err := yaml.Marshal(res.GetOidcJwks())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_tenant.go
+++ b/internal/provider/resource_tenant.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "goauthentik.io/api/v3"
+	"gopkg.in/yaml.v3"
 )
 
 func resourceTenant() *schema.Resource {
@@ -148,7 +148,7 @@ func resourceTenantSchemaToModel(d *schema.ResourceData) (*api.TenantRequest, di
 
 	attr := make(map[string]interface{})
 	if l, ok := d.Get("attributes").(string); ok && l != "" {
-		err := json.NewDecoder(strings.NewReader(l)).Decode(&attr)
+		err := yaml.NewDecoder(strings.NewReader(l)).Decode(&attr)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -209,7 +209,7 @@ func resourceTenantRead(ctx context.Context, d *schema.ResourceData, m interface
 	if res.WebCertificate.IsSet() {
 		setWrapper(d, "web_certificate", res.WebCertificate.Get())
 	}
-	b, err := json.Marshal(res.Attributes)
+	b, err := yaml.Marshal(res.Attributes)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -2,13 +2,13 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "goauthentik.io/api/v3"
+	"gopkg.in/yaml.v3"
 )
 
 func resourceUser() *schema.Resource {
@@ -79,7 +79,7 @@ func resourceUserSchemaToModel(d *schema.ResourceData, c *APIClient) (*api.UserR
 
 	attr := make(map[string]interface{})
 	if l, ok := d.Get("attributes").(string); ok && l != "" {
-		err := json.NewDecoder(strings.NewReader(l)).Decode(&attr)
+		err := yaml.NewDecoder(strings.NewReader(l)).Decode(&attr)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -124,7 +124,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	setWrapper(d, "email", res.Email)
 	setWrapper(d, "is_active", res.IsActive)
 	setWrapper(d, "path", res.Path)
-	b, err := json.Marshal(res.Attributes)
+	b, err := yaml.Marshal(res.Attributes)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Some things like kubeconfig makes more sense to be input as YAML, and since any JSON is valid YAML, `jsonencode` can still be used