### PR TITLE
Use uuid instead of application id

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -31,7 +31,7 @@ resource "authentik_policy_expression" "policy" {
 }
 
 resource "authentik_policy_binding" "app-access" {
-  target = authentik_application.name.id
+  target = authentik_application.name.uuid
   policy = authentik_policy_expression.policy.id
   order  = 0
 }

--- a/docs/resources/policy_binding.md
+++ b/docs/resources/policy_binding.md
@@ -25,7 +25,7 @@ resource "authentik_application" "name" {
 }
 
 resource "authentik_policy_binding" "app-access" {
-  target = authentik_application.name.id
+  target = authentik_application.name.uuid
   policy = authentik_policy_expression.policy.id
   order  = 0
 }
@@ -42,7 +42,7 @@ resource "authentik_application" "name" {
 }
 
 resource "authentik_policy_binding" "app-access" {
-  target = authentik_application.name.id
+  target = authentik_application.name.uuid
   group  = data.authentik_group.admins.id
   order  = 0
 }

--- a/examples/resources/authentik_application/resource.tf
+++ b/examples/resources/authentik_application/resource.tf
@@ -17,7 +17,7 @@ resource "authentik_policy_expression" "policy" {
 }
 
 resource "authentik_policy_binding" "app-access" {
-  target = authentik_application.name.id
+  target = authentik_application.name.uuid
   policy = authentik_policy_expression.policy.id
   order  = 0
 }

--- a/examples/resources/authentik_policy_binding/resource.tf
+++ b/examples/resources/authentik_policy_binding/resource.tf
@@ -11,7 +11,7 @@ resource "authentik_application" "name" {
 }
 
 resource "authentik_policy_binding" "app-access" {
-  target = authentik_application.name.id
+  target = authentik_application.name.uuid
   policy = authentik_policy_expression.policy.id
   order  = 0
 }
@@ -28,7 +28,7 @@ resource "authentik_application" "name" {
 }
 
 resource "authentik_policy_binding" "app-access" {
-  target = authentik_application.name.id
+  target = authentik_application.name.uuid
   group  = data.authentik_group.admins.id
   order  = 0
 }


### PR DESCRIPTION
When using the example as is, this error will be thrown:

```
Error: HTTP Error '400 Bad Request' during request 'POST /api/v3/policies/bindings/': "{"target":["“appid” is not a valid UUID."]}"
```

Using the `uuid` of the application solves the issue.