### PR TITLE
Background URL on `authentik_flow` is set incorrectly

### DIFF
--- a/internal/provider/resource_flow_test.go
+++ b/internal/provider/resource_flow_test.go
@@ -18,12 +18,14 @@ func TestAccResourceFlow(t *testing.T) {
 				Config: testAccResourceFlowSimple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("authentik_flow.flow", "name", rName),
+					resource.TestCheckResourceAttr("authentik_flow.flow", "background", "/media/"+rName+".jpg"),
 				),
 			},
 			{
 				Config: testAccResourceFlowSimple(rName + "test"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("authentik_flow.flow", "name", rName+"test"),
+					resource.TestCheckResourceAttr("authentik_flow.flow", "background", "/media/"+rName+"test"+".jpg"),
 				),
 			},
 		},
@@ -38,7 +40,7 @@ resource "authentik_flow" "flow" {
   slug  ="%[1]s"
   designation = "authorization"
   authentication = "none"
-  background = "https://goauthentik.io"
+  background = "/media/%[1]s.jpg"
   layout = "stacked"
 }
 `, name)


### PR DESCRIPTION
I have only commited a test as i think it will be easier to explain that way.

When setting the `background` property of the resource to something like `/media/test.jpg` this will result in `/media/media/test.jpg`.

I am not sure if this is related to the Terraform provider or Authentik itself, but doing it through the Authentik web interface, sets the url/path correctly.