### PR TITLE
Add VS Code devcontainer.

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -1,0 +1,5 @@
+PG_PASS=local_pg_password
+AUTHENTIK_SECRET_KEY=this-secret-key-is-for-testing-dont-use
+AUTHENTIK_BOOTSTRAP_PASSWORD=this-password-is-for-testing-dont-use
+AUTHENTIK_BOOTSTRAP_TOKEN=this-token-is-for-testing-dont-use
+AUTHENTIK_BOOTSTRAP_EMAIL=akadmin@example.com

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/devcontainers/go:1-1.21-bookworm

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Authentik Terraform Provider",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	"features": {
+		"ghcr.io/devcontainers/features/terraform:1": {}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"mhutchie.git-graph",
+				"ms-azuretools.vscode-docker"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,101 @@
+---
+version: "3.4"
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  postgresql:
+    image: docker.io/library/postgres:12-alpine
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      start_period: 20s
+      interval: 30s
+      retries: 5
+      timeout: 5s
+    volumes:
+      - database:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: ${PG_PASS:?database password required}
+      POSTGRES_USER: ${PG_USER:-authentik}
+      POSTGRES_DB: ${PG_DB:-authentik}
+    env_file:
+      - .env
+  redis:
+    image: docker.io/library/redis:alpine
+    command: --save 60 1 --loglevel warning
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      start_period: 20s
+      interval: 30s
+      retries: 5
+      timeout: 3s
+    volumes:
+      - redis:/data
+  server:
+    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2024.2.2}
+    restart: unless-stopped
+    command: server
+    environment:
+      AUTHENTIK_REDIS__HOST: redis
+      AUTHENTIK_POSTGRESQL__HOST: postgresql
+      AUTHENTIK_POSTGRESQL__USER: ${PG_USER:-authentik}
+      AUTHENTIK_POSTGRESQL__NAME: ${PG_DB:-authentik}
+      AUTHENTIK_POSTGRESQL__PASSWORD: ${PG_PASS}
+    volumes:
+      - ./media:/media
+      - ./custom-templates:/templates
+    env_file:
+      - .env
+    ports:
+      - "${COMPOSE_PORT_HTTP:-9000}:9000"
+      - "${COMPOSE_PORT_HTTPS:-9443}:9443"
+    depends_on:
+      - postgresql
+      - redis
+  worker:
+    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2024.2.2}
+    restart: unless-stopped
+    command: worker
+    environment:
+      AUTHENTIK_REDIS__HOST: redis
+      AUTHENTIK_POSTGRESQL__HOST: postgresql
+      AUTHENTIK_POSTGRESQL__USER: ${PG_USER:-authentik}
+      AUTHENTIK_POSTGRESQL__NAME: ${PG_DB:-authentik}
+      AUTHENTIK_POSTGRESQL__PASSWORD: ${PG_PASS}
+    # `user: root` and the docker socket volume are optional.
+    # See more for the docker socket integration here:
+    # https://goauthentik.io/docs/outposts/integrations/docker
+    # Removing `user: root` also prevents the worker from fixing the permissions
+    # on the mounted folders, so when removing this make sure the folders have the correct UID/GID
+    # (1000:1000 by default)
+    user: root
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./media:/media
+      - ./certs:/certs
+      - ./custom-templates:/templates
+    env_file:
+      - .env
+    depends_on:
+      - postgresql
+      - redis
+
+volumes:
+  database:
+    driver: local
+  redis:
+    driver: local

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       POSTGRES_DB: ${PG_DB:-authentik}
     env_file:
       - .env
+    ports:
+      - "${COMPOSE_PORT_POSTGRES:-5432}:5432"
   redis:
     image: docker.io/library/redis:alpine
     command: --save 60 1 --loglevel warning

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
         "TF_LOG": "trace",
         "TF_ACC": "1",
         "AUTHENTIK_URL": "http://localhost:9000",
-        "AUTHENTIK_TOKEN": "this-password-is-for-testing-dont-use",
+        "AUTHENTIK_TOKEN": "this-token-is-for-testing-dont-use",
     },
     "go.testFlags": ["-count=1"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,8 +19,11 @@
     "go.testEnvVars": {
         "TF_LOG": "trace",
         "TF_ACC": "1",
-        "AUTHENTIK_URL": "http://localhost:9000",
+        "AUTHENTIK_URL": "http://server:9000",
         "AUTHENTIK_TOKEN": "this-token-is-for-testing-dont-use",
     },
-    "go.testFlags": ["-count=1"]
+    "go.testFlags": [
+        "-count=1"
+    ],
+    "go.testTimeout": "30m"
 }

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Run `make` from the project root to regenerate the latest provider documentation
 
 ## Run tests using a Dev Container
 
-Running the included Dev Container will create a full Authentik development environment automatically as if following the instructions found here: https://goauthentik.io/docs/installation/docker-compose
+Running the included Dev Container will create a full authentik development environment automatically as if following the instructions found here: https://goauthentik.io/docs/installation/docker-compose
 
 Once the Dev Container is running, simply use the VS Code Command Palette or Test UI to run any tests as needed.
 
-Note: If running all tests, this is very CPU-intensive on your local Authentik environment, so depending on your hardware they can take several minutes to complete.
+Note: If running all tests, this is very CPU-intensive on your local authentik environment, so depending on your hardware they can take several minutes to complete.
 
 ## Run tests using a local environment
 
@@ -52,7 +52,7 @@ go test -timeout 30m ./... -count=1
 
 If you're trying to run tests with VS Code in your local environment, be sure to change `AUTHENTIK_URL` in `.vscode/settings.json` to: `"AUTHENTIK_URL": "http://localhost:9000"`
 
-Note: If running all tests, this is very CPU-intensive on your local Authentik environment, so depending on your hardware they can take several minutes to complete.
+Note: If running all tests, this is very CPU-intensive on your local authentik environment, so depending on your hardware they can take several minutes to complete.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Start a local authentik instance by following https://goauthentik.io/docs/instal
 Before starting the instance, add this static token to the `.env` file:
 
 ```
-AUTHENTIK_TOKEN=this-password-is-for-testing-dont-use
+AUTHENTIK_TOKEN=this-token-is-for-testing-dont-use
 ```
 
 Afterwards, tests can be run from your Editor or via CLI:
@@ -38,9 +38,20 @@ Afterwards, tests can be run from your Editor or via CLI:
 ```
 export TF_ACC=1
 export AUTHENTIK_URL=http://localhost:9000
-export AUTHENTIK_TOKEN=this-password-is-for-testing-dont-use
-go test -timeout 30s ./... -count=1
+export AUTHENTIK_TOKEN=this-token-is-for-testing-dont-use
+go test -timeout 0 ./... -count=1
 ```
+
+If running from within the devcontainer, use the following instead with the correct URL:
+
+```
+export TF_ACC=1
+export AUTHENTIK_URL=http://server:9000
+export AUTHENTIK_TOKEN=this-token-is-for-testing-dont-use
+go test -timeout 0 ./... -count=1
+```
+
+If you're trying to run tests with VS Code inside the devcontainer, be sure to change `AUTHENTIK_URL` in `.vscode/settings.json` to: `"AUTHENTIK_URL": "http://server:9000"`
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ make build
 
 Run `make` from the project root to regenerate the latest provider documentation
 
-## Testing
+## Run tests using a Dev Container
+
+Running the included Dev Container will create a full Authentik development environment automatically as if following the instructions found here: https://goauthentik.io/docs/installation/docker-compose
+
+Once the Dev Container is running, simply use the VS Code Command Palette or Test UI to run any tests as needed.
+
+Note: If running all tests, this is very CPU-intensive on your local Authentik environment, so depending on your hardware they can take several minutes to complete.
+
+## Run tests using a local environment
 
 Start a local authentik instance by following https://goauthentik.io/docs/installation/docker-compose
 
@@ -33,25 +41,18 @@ Before starting the instance, add this static token to the `.env` file:
 AUTHENTIK_TOKEN=this-token-is-for-testing-dont-use
 ```
 
-Afterwards, tests can be run from your Editor or via CLI:
+Afterwards, tests can be run from VS Code with the Command Palette or Test UI, or via CLI like so:
 
 ```
 export TF_ACC=1
 export AUTHENTIK_URL=http://localhost:9000
 export AUTHENTIK_TOKEN=this-token-is-for-testing-dont-use
-go test -timeout 0 ./... -count=1
+go test -timeout 30m ./... -count=1
 ```
 
-If running from within the devcontainer, use the following instead with the correct URL:
+If you're trying to run tests with VS Code in your local environment, be sure to change `AUTHENTIK_URL` in `.vscode/settings.json` to: `"AUTHENTIK_URL": "http://localhost:9000"`
 
-```
-export TF_ACC=1
-export AUTHENTIK_URL=http://server:9000
-export AUTHENTIK_TOKEN=this-token-is-for-testing-dont-use
-go test -timeout 0 ./... -count=1
-```
-
-If you're trying to run tests with VS Code inside the devcontainer, be sure to change `AUTHENTIK_URL` in `.vscode/settings.json` to: `"AUTHENTIK_URL": "http://server:9000"`
+Note: If running all tests, this is very CPU-intensive on your local Authentik environment, so depending on your hardware they can take several minutes to complete.
 
 ## Versioning
 


### PR DESCRIPTION
Hi there,

Long time listener, first time contributor. (That's not true. I'm new to Authentik as well.)

In trying to keep all of our Infrastructure as Code for our new Authentik deployment I'm implementing, I found that all the new RBAC resources that are in preview apparently are not in this Terraform provider.

With the intention of potentially being able to contribute these new resources myself, I have created this devcontainer, so non-Go developers such as myself can have a more cozy starting place and baseline envrionment with passing tests from which to grow.

Changes:

1. Added the devcontainer.json file itself. The JSON is mostly default with a couple extensions, change however you see fit.
2. The Dockerfile for the devcontainer is based off of the Microsoft Go 1.21 image with no changes. 1.22 is available but I set as 1.21 to match your project files.
3. The .env file contains bootstrap secrets/passwords/tokens for running the Docker Compose Authentik install. All presumably fine to have here as exposing a devcontainer to the Internet would be very questionable anyways.
4. The Docker Compose file is mostly copied from the link in the documentation, https://goauthentik.io/docker-compose.yml, with the minor addition of the new service for the devcontainer itself using the Microsoft image
5. The settings.json file and Readme references were changed to be `this-token-is-for-testing-dont-use` to keep distinct from now the boostrap akadmin password being set in the .env file
6. The tests timeout was set to 0 in the Readme file as I found it took me 132 seconds to run them on my new machine, well over the 30s specified, and I wouldn't want a slower machine scaring any potential contributors off
7. I added separate Readme instructions for running the tests from within the devcontainer, however, it could be considered to remove the localhost-related instructions if deciding upon fully adopting the devcontainer into your normal workflow. A simple change to the docker-compose could also allow access to other instances of Authentik you may be running on localhost too. This would simplify the instructions to new contributors, but I did not wish to affect existing workflows.

Let me know what you think!

Dylan