### PR TITLE
resource_token: fix expires property

### DIFF
--- a/internal/provider/resource_token.go
+++ b/internal/provider/resource_token.go
@@ -122,7 +122,7 @@ func resourceTokenRead(ctx context.Context, d *schema.ResourceData, m interface{
 	setWrapper(d, "user", res.User)
 	setWrapper(d, "description", res.Description)
 	setWrapper(d, "intent", res.Intent)
-	if res.Expires.IsSet() {
+	if res.Expires.IsSet() && res.Expires.Get() != nil {
 		setWrapper(d, "expires_in", time.Until(*res.Expires.Get()).Seconds())
 	}
 	if rt, ok := d.Get("retrieve_key").(bool); ok && rt {


### PR DESCRIPTION
Probably caused by https://github.com/goauthentik/authentik/pull/7410. Should we fix this in authentik if we can?