### PR TITLE
add `Verification Certificate` to SAML source

### DIFF
--- a/docs/resources/source_saml.md
+++ b/docs/resources/source_saml.md
@@ -104,6 +104,7 @@ resource "authentik_source_saml" "name" {
  Defaults to `identifier`.
 - `user_path_template` (String) Defaults to `goauthentik.io/sources/%(slug)s`.
 - `uuid` (String) Generated.
+- `verification_kp` (String)
 
 ### Read-Only
 

--- a/internal/provider/resource_source_saml.go
+++ b/internal/provider/resource_source_saml.go
@@ -115,6 +115,10 @@ func resourceSourceSAML() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"verification_kp": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"digest_algorithm": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -182,6 +186,10 @@ func resourceSourceSAMLSchemaToSource(d *schema.ResourceData) *api.SAMLSourceReq
 	if s, sok := d.GetOk("encryption_kp"); sok && s.(string) != "" {
 		r.EncryptionKp.Set(api.PtrString(s.(string)))
 	}
+	if s, sok := d.GetOk("verification_kp"); sok && s.(string) != "" {
+		r.VerificationKp.Set(api.PtrString(s.(string)))
+	}
+
 	return &r
 }
 
@@ -237,6 +245,9 @@ func resourceSourceSAMLRead(ctx context.Context, d *schema.ResourceData, m inter
 	}
 	if res.EncryptionKp.IsSet() {
 		setWrapper(d, "encryption_kp", res.EncryptionKp.Get())
+	}
+	if res.VerificationKp.IsSet() {
+		setWrapper(d, "verification_kp", res.VerificationKp.Get())
 	}
 	setWrapper(d, "digest_algorithm", res.DigestAlgorithm)
 	setWrapper(d, "signature_algorithm", res.SignatureAlgorithm)


### PR DESCRIPTION
Fixes part of #596.

This only adds the `Verification Certificate` option to the SAML source. I did not have time to fully implement the `Icon` setting as well, with it being more complicated due to the different API endpoints for uploads and URLs and therefore input options. I do have a [branch](https://github.com/matthias-bruhse/terraform-provider-authentik/commit/79dc77de53a7c564b56a96ec2101a5721e0e3586) in my fork that allows setting the icon via URL which is my use case. Might be useful as a starting point, if you get around to work on it.