### PR TITLE
Fix authentik_stage_prompt_field documentation (missing required name field)

### DIFF
--- a/docs/resources/stage_prompt.md
+++ b/docs/resources/stage_prompt.md
@@ -15,6 +15,7 @@ description: |-
 # Create a prompt stage with 1 field
 
 resource "authentik_stage_prompt_field" "field" {
+  name      = "username"
   field_key = "username"
   label     = "Username"
   type      = "username"

--- a/docs/resources/stage_prompt_field.md
+++ b/docs/resources/stage_prompt_field.md
@@ -15,6 +15,7 @@ description: |-
 # Create a prompt field
 
 resource "authentik_stage_prompt_field" "field" {
+  name      = "username"
   field_key = "username"
   label     = "Username"
   type      = "username"

--- a/examples/resources/authentik_stage_prompt/resource.tf
+++ b/examples/resources/authentik_stage_prompt/resource.tf
@@ -1,6 +1,7 @@
 # Create a prompt stage with 1 field
 
 resource "authentik_stage_prompt_field" "field" {
+  name      = "username"
   field_key = "username"
   label     = "Username"
   type      = "username"

--- a/examples/resources/authentik_stage_prompt_field/resource.tf
+++ b/examples/resources/authentik_stage_prompt_field/resource.tf
@@ -1,6 +1,7 @@
 # Create a prompt field
 
 resource "authentik_stage_prompt_field" "field" {
+  name      = "username"
   field_key = "username"
   label     = "Username"
   type      = "username"


### PR DESCRIPTION
This fixes a tiny error/omission in the documentation: `name` is a required attribute for prompt field resources and therefore should be included in the examples.