### PR TITLE
Add support for subpaths configured with AUTHENTIK_WEB__PATH

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -227,6 +227,16 @@ func providerConfigure(version string, testing bool) schema.ConfigureContextFunc
 		config.UserAgent = fmt.Sprintf("authentik-terraform@%s", version)
 		config.Host = akURL.Host
 		config.Scheme = akURL.Scheme
+		// Support subpaths by updating the Servers configuration
+		if akURL.Path != "" && akURL.Path != "/" {
+			basePath := strings.TrimSuffix(akURL.Path, "/")
+			config.Servers = api.ServerConfigurations{
+				{
+					URL:         basePath + "/api/v3",
+					Description: "authentik API",
+				},
+			}
+		}
 		config.HTTPClient = &http.Client{
 			Transport: GetTLSTransport(insecure),
 		}


### PR DESCRIPTION
If Authentik server is configured with the env var `AUTHENTIK_WEB__PATH`, the `/api/v3` endpoint moves with it; the terraform provider should allow taking the path from the URL specified and including it when making API calls.