### PR TITLE
Bumped devcontainer version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/devcontainers/go:2-1.25-bookworm
+FROM mcr.microsoft.com/devcontainers/go:dev-1.26-bookworm


### PR DESCRIPTION
The devcontainer currently uses `FROM mcr.microsoft.com/devcontainers/go:2-1.25-bookworm` as a base but the modules Go version was recently bumped up to 1.26.

This PR just bumps the base image to `FROM mcr.microsoft.com/devcontainers/go:dev-1.26-bookworm`.