### PR TITLE
Fix issue with not_configure_action not parsing string input 

### DIFF
--- a/pkg/provider/resource_stage_authenticator_validate.go
+++ b/pkg/provider/resource_stage_authenticator_validate.go
@@ -76,7 +76,7 @@ func resourceStageAuthenticatorValidateSchemaToProvider(d *schema.ResourceData) 
 		Name:                       d.Get("name").(string),
 		LastAuthThreshold:          new(d.Get("last_auth_threshold").(string)),
 		WebauthnAllowedDeviceTypes: helpers.CastSlice[string](d, "webauthn_allowed_device_types"),
-		NotConfiguredAction:        helpers.GetP[api.NotConfiguredActionEnum](d, "not_configured_action"),
+		NotConfiguredAction:        helpers.CastString[api.NotConfiguredActionEnum](helpers.GetP[string](d, "not_configured_action")),
 		ConfigurationStages:        helpers.CastSlice[string](d, "configuration_stages"),
 		WebauthnUserVerification:   helpers.CastString[api.UserVerificationEnum](helpers.GetP[string](d, "webauthn_user_verification")),
 	}

--- a/pkg/provider/resource_stage_authenticator_validate_test.go
+++ b/pkg/provider/resource_stage_authenticator_validate_test.go
@@ -15,22 +15,31 @@ func TestAccResourceStageAuthenticatorValidate(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceStageAuthenticatorValidate(rName),
+				Config: testAccResourceStageAuthenticatorValidateAction(rName, "skip"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "name", rName),
+					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "not_configured_action", "skip"),
 				),
 			},
 			{
-				Config: testAccResourceStageAuthenticatorValidate(rName + "test"),
+				Config: testAccResourceStageAuthenticatorValidateAction(rName, "deny"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "name", rName+"test"),
+					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "name", rName),
+					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "not_configured_action", "deny"),
+				),
+			},
+			{
+				Config: testAccResourceStageAuthenticatorValidateAction(rName, "configure"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "name", rName),
+					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "not_configured_action", "configure"),
 				),
 			},
 		},
 	})
 }
 
-func testAccResourceStageAuthenticatorValidate(name string) string {
+func testAccResourceStageAuthenticatorValidateAction(name string, action string) string {
 	return fmt.Sprintf(`
 resource "authentik_stage_authenticator_totp" "name" {
   name              = "%[1]s-setup"
@@ -39,10 +48,10 @@ resource "authentik_stage_authenticator_totp" "name" {
 resource "authentik_stage_authenticator_validate" "name" {
   name              = "%[1]s"
   device_classes = ["static"]
-  not_configured_action = "skip"
+  not_configured_action = "%[2]s"
   configuration_stages = [
     authentik_stage_authenticator_totp.name.id,
   ]
 }
-`, name)
+`, name, action)
 }


### PR DESCRIPTION
git@github.com:krazykeith/terraform-providerys defaulting to skip.

Ran tests against local authentik instance. 

Screen shots of results with delete disabled initally so i can look at results

<img width="1131" height="900" alt="image" src="https://github.com/user-attachments/assets/efac211d-24fe-45b2-b83a-b98c2b76303c" />

<img width="1142" height="896" alt="image" src="https://github.com/user-attachments/assets/044b1d45-5516-472b-9fbc-020cd16443e3" />

<img width="1138" height="897" alt="image" src="https://github.com/user-attachments/assets/9f6c7269-035c-4c1e-b383-d35d80fc5f48" />

Fixes #802 