### PR TITLE
Fix swapped captcha stage threshold defaults

### DIFF
--- a/docs/resources/stage_captcha.md
+++ b/docs/resources/stage_captcha.md
@@ -36,8 +36,8 @@ resource "authentik_stage_captcha" "name" {
 - `error_on_invalid_score` (Boolean) Defaults to `true`.
 - `interactive` (Boolean) Defaults to `false`.
 - `js_url` (String) Defaults to `https://www.recaptcha.net/recaptcha/api.js`.
-- `score_max_threshold` (Number) Defaults to `0.5`.
-- `score_min_threshold` (Number) Defaults to `1`.
+- `score_min_threshold` (Number) Defaults to `0.5`.
+- `score_max_threshold` (Number) Defaults to `1`.
 
 ### Read-Only
 

--- a/pkg/provider/resource_stage_captcha.go
+++ b/pkg/provider/resource_stage_captcha.go
@@ -46,12 +46,12 @@ func resourceStageCaptcha() *schema.Resource {
 			"score_min_threshold": {
 				Type:     schema.TypeFloat,
 				Optional: true,
-				Default:  1,
+				Default:  0.5,
 			},
 			"score_max_threshold": {
 				Type:     schema.TypeFloat,
 				Optional: true,
-				Default:  0.5,
+				Default:  1,
 			},
 			"error_on_invalid_score": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
I noticed that a captcha stage I set up via terraform provider was not working whereas one set up through the UI worked well. I tracked it down to the terraform provider having "swapped" defaults for the threshold values.

This PR fixes this and aligns the defaults with the defaults in the Authentik code: https://github.com/goauthentik/authentik/blob/b5deeaa822bdd10d38daa69b70a9128f10e67408/authentik/stages/captcha/models.py#L19-L20