### PR TITLE
provider_oauth2: round-trip redirect_uri_type on allowed_redirect_uris

### DIFF
--- a/pkg/provider/resource_provider_oauth2.go
+++ b/pkg/provider/resource_provider_oauth2.go
@@ -211,30 +211,45 @@ func resourceProviderOAuth2SchemaToProvider(d *schema.ResourceData) *api.OAuth2P
 	return &r
 }
 
+func redirectURITypeFromMap(rd map[string]any) *api.RedirectURITypeEnum {
+	v, ok := rd["redirect_uri_type"].(string)
+	if !ok || v == "" {
+		return nil
+	}
+	t := api.RedirectURITypeEnum(v)
+	return &t
+}
+
 func listToRedirectURIsRequest(raw []any) []api.RedirectURIRequest {
 	rus := []api.RedirectURIRequest{}
 	for _, rr := range raw {
 		rd := rr.(map[string]any)
 		rus = append(rus, api.RedirectURIRequest{
-			MatchingMode: api.MatchingModeEnum(rd["matching_mode"].(string)),
-			Url:          rd["url"].(string),
+			MatchingMode:    api.MatchingModeEnum(rd["matching_mode"].(string)),
+			Url:             rd["url"].(string),
+			RedirectUriType: redirectURITypeFromMap(rd),
 		})
 	}
 	return rus
 }
 
 type CustomRedirectURI struct {
-	MatchingMode api.MatchingModeEnum `json:"matching_mode"`
-	Url          string               `json:"url"`
+	MatchingMode    api.MatchingModeEnum    `json:"matching_mode"`
+	Url             string                  `json:"url"`
+	RedirectUriType api.RedirectURITypeEnum `json:"redirect_uri_type,omitempty"`
 }
 
 func castRedirectURIs(raw []api.RedirectURI) []CustomRedirectURI {
 	rus := make([]CustomRedirectURI, len(raw))
 	for i, r := range raw {
-		rus[i] = CustomRedirectURI{
+		c := CustomRedirectURI{
 			MatchingMode: r.MatchingMode,
 			Url:          r.Url,
 		}
+		if r.RedirectUriType != nil {
+			c.RedirectUriType = *r.RedirectUriType
+		}
+		rus[i] = c
 	}
 	return rus
 }
@@ -243,10 +258,14 @@ func listToRedirectURIs(raw []any) []CustomRedirectURI {
 	rus := []CustomRedirectURI{}
 	for _, rr := range raw {
 		rd := rr.(map[string]any)
-		rus = append(rus, CustomRedirectURI{
+		c := CustomRedirectURI{
 			MatchingMode: api.MatchingModeEnum(rd["matching_mode"].(string)),
 			Url:          rd["url"].(string),
-		})
+		}
+		if t := redirectURITypeFromMap(rd); t != nil {
+			c.RedirectUriType = *t
+		}
+		rus = append(rus, c)
 	}
 	return rus
 }
@@ -254,10 +273,14 @@ func listToRedirectURIs(raw []any) []CustomRedirectURI {
 func redirectURIsToList(raw []CustomRedirectURI) []map[string]any {
 	rus := []map[string]any{}
 	for _, rr := range raw {
-		rus = append(rus, map[string]any{
+		entry := map[string]any{
 			"matching_mode": string(rr.MatchingMode),
 			"url":           rr.Url,
-		})
+		}
+		if rr.RedirectUriType != "" {
+			entry["redirect_uri_type"] = string(rr.RedirectUriType)
+		}
+		rus = append(rus, entry)
 	}
 	return rus
 }

--- a/pkg/provider/resource_provider_oauth2_test.go
+++ b/pkg/provider/resource_provider_oauth2_test.go
@@ -20,6 +20,8 @@ func TestAccResourceProviderOAuth2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "name", rName),
 					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "client_id", rName),
+					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "allowed_redirect_uris.0.redirect_uri_type", "authorization"),
+					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "allowed_redirect_uris.1.redirect_uri_type", "logout"),
 					resource.TestCheckResourceAttr("authentik_application.name", "name", appName),
 					resource.TestCheckResourceAttr("authentik_application.name", "slug", appName),
 				),
@@ -29,6 +31,8 @@ func TestAccResourceProviderOAuth2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "name", rName+"test"),
 					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "client_id", rName+"test"),
+					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "allowed_redirect_uris.0.redirect_uri_type", "authorization"),
+					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "allowed_redirect_uris.1.redirect_uri_type", "logout"),
 					resource.TestCheckResourceAttr("authentik_application.name", "name", appName+"test"),
 					resource.TestCheckResourceAttr("authentik_application.name", "slug", appName+"test"),
 				),
@@ -89,8 +93,14 @@ resource "authentik_provider_oauth2" "name" {
   invalidation_flow = data.authentik_flow.default-provider-invalidation-flow.id
   allowed_redirect_uris = [
     {
-      matching_mode = "strict",
-	  url = "http://localhost",
+      matching_mode     = "strict",
+      url               = "http://localhost/callback",
+      redirect_uri_type = "authorization",
+    },
+    {
+      matching_mode     = "strict",
+      url               = "http://localhost/",
+      redirect_uri_type = "logout",
     }
   ]
 }


### PR DESCRIPTION
## Summary

Plumbs the `redirect_uri_type` field through `authentik_provider_oauth2.allowed_redirect_uris` so that `"logout"`-typed entries are actually sent to authentik and read back from state.

## Why

Authentik's API returns each entry of `redirect_uris` with a `redirect_uri_type` enum (`authorization` or `logout`). In authentik 2026.5+, `end-session/?post_logout_redirect_uri=...` will return `400 Bad Request — The request is otherwise malformed` unless the post-logout redirect URI matches an entry whose `redirect_uri_type` is `logout`.

Today the provider's `CustomRedirectURI` mirror struct and the conversion helpers (`listToRedirectURIsRequest`, `castRedirectURIs`, `listToRedirectURIs`, `redirectURIsToList`) only carry `matching_mode` and `url`. As a result:

1. HCL that includes `redirect_uri_type = "logout"` has the field **silently dropped** before the API call — every entry ends up typed `authorization` server-side.
2. The next `Read` round-trips the state with no `redirect_uri_type`, so terraform never plans a corrective update.
3. RP-initiated logout (`/application/o/<slug>/end-session/`) returns 400 even though the configured URL is correct.

This is in the same family of "field silently dropped" issues being tracked in #890, #894, #895, #898.

## What changed

- `pkg/provider/resource_provider_oauth2.go`
  - Add `RedirectUriType` to `CustomRedirectURI`.
  - Plumb the field through `listToRedirectURIsRequest`, `castRedirectURIs`, `listToRedirectURIs`, and `redirectURIsToList`.
  - Empty string is treated as "no value" so existing configs that don't set the field round-trip unchanged.
- `pkg/provider/resource_provider_oauth2_test.go`
  - Extend `TestAccResourceProviderOAuth2` with one `authorization`- and one `logout`-typed entry, and assert both round-trip correctly.

The schema for `allowed_redirect_uris` (a `TypeList` of `TypeMap`) doesn't change — the field was already accepted at parse time, it just wasn't read.

## Test plan

- [x] `go build ./...` (clean)
- [x] `go vet ./...` (clean)
- [x] `go test -run '^TestNothing$' ./...` (tests compile)
- [ ] `make test` (acceptance suite — needs a live authentik backend; not run locally)

Manual repro that motivated this PR: with authentik 2026.5.2 and the provider on `main`, configuring an OIDC client where the React SPA's logout endpoint redirects to `http://localhost:8080/`, the `Log out` button consistently hits `400` because the URI is only typed `authorization`. With this PR applied locally and the same HCL, the post-logout redirect resolves cleanly and `default-provider-invalidation-flow` runs.