### PR TITLE
Fix missing read/import attributes for brand and password policy resources

### DIFF
--- a/pkg/provider/resource_brand.go
+++ b/pkg/provider/resource_brand.go
@@ -158,6 +158,7 @@ func resourceBrandRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 	}
 
 	helpers.SetWrapper(d, "domain", res.Domain)
+	helpers.SetWrapper(d, "default", res.Default)
 	helpers.SetWrapper(d, "branding_title", res.BrandingTitle)
 	helpers.SetWrapper(d, "branding_logo", res.BrandingLogo)
 	helpers.SetWrapper(d, "branding_favicon", res.BrandingFavicon)

--- a/pkg/provider/resource_policy_password.go
+++ b/pkg/provider/resource_policy_password.go
@@ -154,6 +154,15 @@ func resourcePolicyPasswordRead(ctx context.Context, d *schema.ResourceData, m a
 	helpers.SetWrapper(d, "amount_digits", res.AmountDigits)
 	helpers.SetWrapper(d, "length_min", res.LengthMin)
 	helpers.SetWrapper(d, "symbol_charset", res.SymbolCharset)
+
+	helpers.SetWrapper(d, "check_static_rules", res.CheckStaticRules)
+
+	helpers.SetWrapper(d, "check_have_i_been_pwned", res.CheckHaveIBeenPwned)
+	helpers.SetWrapper(d, "hibp_allowed_count", res.HibpAllowedCount)
+
+	helpers.SetWrapper(d, "check_zxcvbn", res.CheckZxcvbn)
+	helpers.SetWrapper(d, "zxcvbn_score_threshold", res.ZxcvbnScoreThreshold)
+
 	return diags
 }
 


### PR DESCRIPTION
When importing or reading authentik_brand or authentik_policy_password resources some attributes were not being returned correctly, resulting in inaccurate changes or incorrect use of attributes in other expressions.

Missing attributes on authentik_brand:
- default

Missing attributes on authentik_policy_password:
- check_static_rules
- check_have_i_been_pwned
- hibp_allowed_count
- check_zxcvbn
- zxcvbn_score_threshold
