### PR TITLE
Add client id to oauth data source

### DIFF
--- a/docs/data-sources/provider_oauth2_config.md
+++ b/docs/data-sources/provider_oauth2_config.md
@@ -23,6 +23,7 @@ Get OAuth2 provider config
 
 - `authorize_url` (String) Generated.
 - `id` (String) The ID of this resource.
+- `client_id` (String) Generated.
 - `issuer_url` (String) Generated.
 - `jwks_url` (String) Generated.
 - `logout_url` (String) Generated.

--- a/pkg/provider/data_source_provider_oauth_config2.go
+++ b/pkg/provider/data_source_provider_oauth_config2.go
@@ -55,6 +55,10 @@ func dataSourceProviderOAuth2Config() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"client_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -63,6 +67,8 @@ func dataSourceProviderOAuth2ConfigRead(ctx context.Context, d *schema.ResourceD
 	var diags diag.Diagnostics
 	c := m.(*APIClient)
 
+	var clientId *string
+	var finalId int32
 	id, ok := d.GetOk("provider_id")
 	if !ok {
 		req := c.client.ProvidersAPI.ProvidersOauth2List(ctx)
@@ -77,8 +83,17 @@ func dataSourceProviderOAuth2ConfigRead(ctx context.Context, d *schema.ResourceD
 			return diag.Errorf("no matching providers found")
 		}
 		id = int(res.Results[0].Pk)
+		finalId = int32(id.(int))
+		clientId = res.Results[0].ClientId
+	} else {
+		finalId = int32(id.(int))
+		req := c.client.ProvidersAPI.ProvidersOauth2Retrieve(ctx, finalId)
+		res, hr, err := req.Execute()
+		if err != nil {
+			return helpers.HTTPToDiag(d, hr, err)
+		}
+		clientId = res.ClientId
 	}
-	finalId := int32(id.(int))
 	d.SetId(strconv.FormatInt(int64(finalId), 10))
 
 	meta, hr, err := c.client.ProvidersAPI.ProvidersOauth2SetupUrlsRetrieve(ctx, finalId).Execute()
@@ -92,5 +107,6 @@ func dataSourceProviderOAuth2ConfigRead(ctx context.Context, d *schema.ResourceD
 	helpers.SetWrapper(d, "provider_info_url", meta.ProviderInfo)
 	helpers.SetWrapper(d, "logout_url", meta.Logout)
 	helpers.SetWrapper(d, "jwks_url", meta.Jwks)
+	helpers.SetWrapper(d, "client_id", clientId)
 	return diags
 }

--- a/pkg/provider/data_source_provider_oauth_config2_test.go
+++ b/pkg/provider/data_source_provider_oauth_config2_test.go
@@ -10,13 +10,14 @@ import (
 
 func TestAccDataSourceOAuth2ProviderConfig(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	clientId := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	appName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceOAuth2ProviderConfigSimple(rName, appName),
+				Config: testAccDataSourceOAuth2ProviderConfigSimple(rName, clientId, appName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "name", rName),
 					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "client_id", rName),
@@ -29,13 +30,22 @@ func TestAccDataSourceOAuth2ProviderConfig(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.authentik_provider_oauth2_config.name", "provider_info_url"),
 					resource.TestCheckResourceAttrSet("data.authentik_provider_oauth2_config.name", "logout_url"),
 					resource.TestCheckResourceAttrSet("data.authentik_provider_oauth2_config.name", "jwks_url"),
+					resource.TestCheckResourceAttr("data.authentik_provider_oauth2_config.name", "client_id", clientId),
+					resource.TestCheckResourceAttrSet("data.authentik_provider_oauth2_config.id", "issuer_url"),
+					resource.TestCheckResourceAttrSet("data.authentik_provider_oauth2_config.id", "authorize_url"),
+					resource.TestCheckResourceAttrSet("data.authentik_provider_oauth2_config.id", "token_url"),
+					resource.TestCheckResourceAttrSet("data.authentik_provider_oauth2_config.id", "user_info_url"),
+					resource.TestCheckResourceAttrSet("data.authentik_provider_oauth2_config.id", "provider_info_url"),
+					resource.TestCheckResourceAttrSet("data.authentik_provider_oauth2_config.id", "logout_url"),
+					resource.TestCheckResourceAttrSet("data.authentik_provider_oauth2_config.id", "jwks_url"),
+					resource.TestCheckResourceAttr("data.authentik_provider_oauth2_config.id", "client_id", clientId),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceOAuth2ProviderConfigSimple(name string, appName string) string {
+func testAccDataSourceOAuth2ProviderConfigSimple(name string, clientId string, appName string) string {
 	return fmt.Sprintf(`
 data "authentik_flow" "default-authorization-flow" {
   slug = "default-provider-authorization-implicit-consent"
@@ -50,7 +60,7 @@ data "authentik_certificate_key_pair" "generated" {
 }
 resource "authentik_provider_oauth2" "name" {
   name      = "%[1]s"
-  client_id = "%[1]s"
+  client_id = "%[2]s"
   # client_secret = "test"
   signing_key = data.authentik_certificate_key_pair.generated.id
   authorization_flow = data.authentik_flow.default-authorization-flow.id
@@ -58,8 +68,8 @@ resource "authentik_provider_oauth2" "name" {
 }
 
 resource "authentik_application" "name" {
-  name              = "%[2]s"
-  slug              = "%[2]s"
+  name              = "%[3]s"
+  slug              = "%[3]s"
   protocol_provider = authentik_provider_oauth2.name.id
 }
 
@@ -69,5 +79,12 @@ data "authentik_provider_oauth2_config" "name" {
 	authentik_application.name
   ]
 }
-`, name, appName)
+
+data "authentik_provider_oauth2_config" "id" {
+  provider_id = authentik_provider_oauth2.name.id
+  depends_on = [
+	authentik_application.name
+  ]
+}
+`, name, clientId, appName)
 }

--- a/pkg/provider/data_source_provider_oauth_config2_test.go
+++ b/pkg/provider/data_source_provider_oauth_config2_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceOAuth2ProviderConfig(t *testing.T) {
 				Config: testAccDataSourceOAuth2ProviderConfigSimple(rName, clientId, appName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "name", rName),
-					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "client_id", rName),
+					resource.TestCheckResourceAttr("authentik_provider_oauth2.name", "client_id", clientId),
 					resource.TestCheckResourceAttr("authentik_application.name", "name", appName),
 					resource.TestCheckResourceAttr("authentik_application.name", "slug", appName),
 					resource.TestCheckResourceAttrSet("data.authentik_provider_oauth2_config.name", "issuer_url"),


### PR DESCRIPTION
This PR extends the authentik_provider_oauth2_config data source to expose the OAuth2 provider’s client_id, aligning the data source output with fields commonly needed to configure downstream OAuth2/OIDC integrations.

Changes:

Added a computed client_id attribute to the authentik_provider_oauth2_config data source schema and set it during read.
Updated the data source read path to fetch client_id when resolving by provider_id.
Updated acceptance tests and data source documentation to include client_id.

Resolves #925 