### PR TITLE
fix: preserve authentik_group roles ordering

### DIFF
--- a/pkg/provider/resource_group.go
+++ b/pkg/provider/resource_group.go
@@ -112,7 +112,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 		helpers.Slice32ToInt(res.Users),
 	))
 	helpers.SetWrapper(d, "roles", helpers.ListConsistentMerge(
-		helpers.CastSlice[string](d, "role"),
+		helpers.CastSlice[string](d, "roles"),
 		res.Roles,
 	))
 	return helpers.SetJSON(d, "attributes", res.Attributes)

--- a/pkg/provider/resource_group_test.go
+++ b/pkg/provider/resource_group_test.go
@@ -2,10 +2,17 @@ package provider
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	api "goauthentik.io/api/v3"
+	"goauthentik.io/terraform-provider-authentik/pkg/helpers"
 )
 
 func TestAccResourceGroup(t *testing.T) {
@@ -48,4 +55,56 @@ resource "authentik_group" "group" {
   roles = [authentik_rbac_role.role.id]
 }
 `, name)
+}
+
+func TestResourceGroupReadRolesPreserveConfiguredOrder(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v3/core/groups/group-1/", r.URL.Path)
+		assert.Equal(t, "false", r.URL.Query().Get("include_users"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"pk": "group-1",
+			"num_pk": 1,
+			"name": "infrastructure",
+			"is_superuser": false,
+			"parents": [],
+			"parents_obj": [],
+			"users": [],
+			"users_obj": [],
+			"attributes": {},
+			"roles": ["role-c", "role-a", "role-b", "role-d"],
+			"roles_obj": [],
+			"inherited_roles_obj": [],
+			"children": [],
+			"children_obj": []
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	config := api.NewConfiguration()
+	config.Servers = api.ServerConfigurations{{
+		URL: server.URL + "/api/v3",
+	}}
+	client := &APIClient{
+		client: api.NewAPIClient(config),
+	}
+
+	d := schema.TestResourceDataRaw(t, resourceGroup().Schema, map[string]any{
+		"name":       "infrastructure",
+		"attributes": "{}",
+		"roles":      []any{"role-a", "role-b", "role-c"},
+	})
+	d.SetId("group-1")
+
+	diags := resourceGroupRead(t.Context(), d, client)
+
+	require.False(t, diags.HasError(), diags)
+	assert.Equal(t, []string{
+		"role-a",
+		"role-b",
+		"role-c",
+		"role-d",
+	}, helpers.CastSlice[string](d, "roles"))
 }


### PR DESCRIPTION
Fixes #929.

`authentik_group.roles` already uses `ListConsistentMerge` to keep Terraform's configured order, but the read path looked up the nonexistent `role` key. That discarded the previous order and let the API response create a perpetual diff.

This changes the lookup to `roles`. The regression test returns the same role IDs in a different order and verifies that existing roles keep their configured order while a new role is appended.

Checks:

- `go test -race ./pkg/provider -run '^TestResourceGroupReadRolesPreserveConfiguredOrder$' -count=1`
- `go test ./pkg/provider -run '^(TestProvider|TestProviderConfigure_PathBasedURL|TestResourceGroupReadRolesPreserveConfiguredOrder)$' -count=1`
- `go test ./pkg/helpers -count=1`
- `go test ./... -run '^$' -count=1`
- `go build ./...`
- `go vet ./...`
