### PR TITLE
stage_authenticator_validate: fix not_configured_action not persisted on update

### DIFF
--- a/pkg/provider/resource_stage_authenticator_validate.go
+++ b/pkg/provider/resource_stage_authenticator_validate.go
@@ -105,7 +105,7 @@ func resourceStageAuthenticatorValidateSchemaToProvider(d *schema.ResourceData) 
 		Name:                       d.Get("name").(string),
 		LastAuthThreshold:          new(d.Get("last_auth_threshold").(string)),
 		WebauthnAllowedDeviceTypes: helpers.CastSlice[string](d, "webauthn_allowed_device_types"),
-		NotConfiguredAction:        helpers.CastString[api.NotConfiguredActionEnum](helpers.GetP[string](d, "not_configured_action")),
+		NotConfiguredAction:        helpers.CastString[api.NotConfiguredActionEnum](api.PtrString(d.Get("not_configured_action").(string))),
 		ConfigurationStages:        helpers.CastSlice[string](d, "configuration_stages"),
 		WebauthnUserVerification:   helpers.CastString[api.UserVerificationEnum](helpers.GetP[string](d, "webauthn_user_verification")),
 		EmailOtpThrottlingFactor:   new(d.Get("email_otp_throttling_factor").(float64)),

--- a/pkg/provider/resource_stage_authenticator_validate_test.go
+++ b/pkg/provider/resource_stage_authenticator_validate_test.go
@@ -1,12 +1,49 @@
 package provider
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	api "goauthentik.io/api/v3"
 )
+
+func TestResourceStageAuthenticatorValidateSchemaToProvider(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		action   string
+		expected api.NotConfiguredActionEnum
+	}{
+		{"skip", "skip", api.NOTCONFIGUREDACTIONENUM_SKIP},
+		{"deny", "deny", api.NOTCONFIGUREDACTIONENUM_DENY},
+		{"configure", "configure", api.NOTCONFIGUREDACTIONENUM_CONFIGURE},
+		// `not_configured_action` is Required, so it must always end up in the request
+		// body. Sourcing it via `helpers.GetP` (`d.GetOk`) yielded a nil pointer for the
+		// zero value, and the model's `omitempty` then dropped the field from the UPDATE
+		// PUT entirely, leaving authentik on its own default.
+		{"zero value is still serialized", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, resourceStageAuthenticatorValidate().Schema, map[string]any{
+				"name":                  "test",
+				"not_configured_action": tc.action,
+			})
+			r := resourceStageAuthenticatorValidateSchemaToProvider(d)
+
+			require.NotNil(t, r.NotConfiguredAction, "not_configured_action must never be nil")
+			assert.Equal(t, tc.expected, *r.NotConfiguredAction)
+
+			b, err := json.Marshal(r)
+			assert.NoError(t, err)
+			assert.Contains(t, string(b), `"not_configured_action"`, "not_configured_action must never be omitted from the request body")
+		})
+	}
+}
 
 func TestAccResourceStageAuthenticatorValidate(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -16,27 +53,43 @@ func TestAccResourceStageAuthenticatorValidate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceStageAuthenticatorValidateAction(rName, "skip"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "name", rName),
-					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "not_configured_action", "skip"),
-				),
+				Check:  testAccResourceStageAuthenticatorValidateCheck(rName, "skip"),
 			},
 			{
 				Config: testAccResourceStageAuthenticatorValidateAction(rName, "deny"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "name", rName),
-					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "not_configured_action", "deny"),
-				),
+				Check:  testAccResourceStageAuthenticatorValidateCheck(rName, "deny"),
 			},
 			{
 				Config: testAccResourceStageAuthenticatorValidateAction(rName, "configure"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "name", rName),
-					resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "not_configured_action", "configure"),
-				),
+				Check:  testAccResourceStageAuthenticatorValidateCheck(rName, "configure"),
 			},
 		},
 	})
+}
+
+// testAccResourceStageAuthenticatorValidateCheck asserts every attribute, not just the one being
+// flipped, so that a field silently dropped from the UPDATE body shows up. All values below
+// deliberately differ from the schema/server defaults, otherwise a dropped field is invisible.
+func testAccResourceStageAuthenticatorValidateCheck(name string, action string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "name", name),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "not_configured_action", action),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "device_classes.#", "1"),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "device_classes.0", "static"),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "configuration_stages.#", "1"),
+		resource.TestCheckResourceAttrPair(
+			"authentik_stage_authenticator_validate.name", "configuration_stages.0",
+			"authentik_stage_authenticator_totp.name", "id",
+		),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "last_auth_threshold", "minutes=5"),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "webauthn_user_verification", "required"),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "webauthn_hints.#", "1"),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "webauthn_hints.0", "security-key"),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "email_otp_throttling_factor", "2"),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "sms_otp_throttling_factor", "2"),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "totp_otp_throttling_factor", "2"),
+		resource.TestCheckResourceAttr("authentik_stage_authenticator_validate.name", "static_otp_throttling_factor", "2"),
+	)
 }
 
 func testAccResourceStageAuthenticatorValidateAction(name string, action string) string {
@@ -52,6 +105,13 @@ resource "authentik_stage_authenticator_validate" "name" {
   configuration_stages = [
     authentik_stage_authenticator_totp.name.id,
   ]
+  last_auth_threshold = "minutes=5"
+  webauthn_user_verification = "required"
+  webauthn_hints = ["security-key"]
+  email_otp_throttling_factor = 2
+  sms_otp_throttling_factor = 2
+  totp_otp_throttling_factor = 2
+  static_otp_throttling_factor = 2
 }
 `, name, action)
 }


### PR DESCRIPTION
## Problem

`authentik_stage_authenticator_validate.not_configured_action` is accepted at plan/apply time but **not persisted on UPDATE**. `terraform apply` reports the change, but the live value reverts to its previous setting (typically `skip`), so MFA-enforcement intent (`deny`/`configure`) is silently lost and the resource never converges — every subsequent plan shows the same diff.

Relates to #895 (same symptom; this PR pinpoints the cause in the provider's request serialization and fixes it).

## Root cause

`not_configured_action` is a **Required** schema field, but `resourceStageAuthenticatorValidateSchemaToProvider` sourced it through `helpers.GetP` (`d.GetOk`), which can return `nil`. The generated `AuthenticatorValidateStageRequest.NotConfiguredAction` is `*NotConfiguredActionEnum` with `json:"not_configured_action,omitempty"`, and `ToMap` only emits it `if !IsNil(...)`. So when `GetP` yields `nil`, the field is **omitted from the UPDATE PUT body entirely**, and authentik keeps the existing value.

Wire capture of the UPDATE request (note the absent field):

```json
{"configuration_stages":[],"device_classes":["webauthn"],"last_auth_threshold":"seconds=0","name":"passkey-challenge","webauthn_allowed_device_types":[],"webauthn_user_verification":"required"}
```

A direct API `PATCH {"not_configured_action":"deny"}` persists fine, confirming the API is not at fault — only the provider's UPDATE payload.

## Fix

Source the Required field via `d.Get` (always present), exactly like the other Required field `name`, so it is always serialized:

```go
NotConfiguredAction: helpers.CastString[api.NotConfiguredActionEnum](api.PtrString(d.Get("not_configured_action").(string))),
```

## Verification

Built the provider from this branch and tested against a live **authentik 2026.2.2** instance via `dev_overrides`:

1. Reset the stage to `not_configured_action = "skip"`.
2. `apply` with config `not_configured_action = "deny"` → API now stores `deny`.
3. Re-`plan` → no changes (converged).

Create is unaffected (`d.Get` returns the configured value there too).